### PR TITLE
Fix broken android studio link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Updated May 2017
 
 # 1. Get the IDE
 
-Android Studio, based on Intellij, can be downloaded from [d.android.com/studio](d.android.com/studio), the latest from the stable channel is what you will get when you click the big green button.  Install the download.
+Android Studio, based on Intellij, can be downloaded from [d.android.com/studio](https://developer.android.com/studio/index.html), the latest from the stable channel is what you will get when you click the big green button.  Install the download.
 
 Caution, you are not done yet!
 


### PR DESCRIPTION
@mscheel I noticed that the link posted for downloading Android Studio hits a github 404. This PR directs the clicker to what I'm assuming is the appropriate Android Studio download page. If I've missed something or this isn't the correct link please let me know. See you tonight! Cheers! 👍 